### PR TITLE
Fix Rust version for `document` job in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ env.nightly }}
           override: true
           profile: minimal
 


### PR DESCRIPTION
Tiny fix related to the failing documentation job in CI.